### PR TITLE
set compatible MinIO version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -212,7 +212,7 @@ services:
     restart: always
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2020-05-01T22-19-14Z
     #ports:
     #  - '9000:9000'
     volumes:


### PR DESCRIPTION
minio:latest breaks compatibility.
change to fixed version.
according to https://github.com/reportportal/reportportal/issues/956#issuecomment-625950695

#956 