### PR TITLE
[EPMRPP-56222] Log limits management

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
 
   gateway:
     image: traefik:v2.0.5
+    logging:
+      driver: "json-file"
+      options:
+        max-file: 5
+        max-size: 10m
     ports:
       - "8080:8080" # HTTP exposed
       - "8081:8081" # HTTP Administration exposed
@@ -32,6 +37,11 @@ services:
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.3.0
+    logging:
+      driver: "json-file"
+      options:
+        max-file: 5
+        max-size: 10m
     volumes:
       - ./data/elasticsearch:/usr/share/elasticsearch/data
     environment:
@@ -55,6 +65,11 @@ services:
 
   analyzer:
     image: reportportal/service-auto-analyzer:5.3.1
+    logging:
+      driver: "json-file"
+      options:
+        max-file: 5
+        max-size: 10m
     environment:
       LOGGING_LEVEL: info
       AMQP_URL: amqp://rabbitmq:rabbitmq@rabbitmq:5672
@@ -79,6 +94,11 @@ services:
 
   postgres:
     image: postgres:12-alpine
+    logging:
+      driver: "json-file"
+      options:
+        max-file: 10
+        max-size: 10m
     shm_size: '512m'
     environment:
       POSTGRES_USER: rpuser
@@ -120,6 +140,11 @@ services:
 
   rabbitmq:
     image: rabbitmq:3.7.16-management
+    logging:
+      driver: "json-file"
+      options:
+        max-file: 5
+        max-size: 10m
     #ports:
       # - "5672:5672"
       #- "15672:15672"
@@ -133,6 +158,11 @@ services:
 
   uat:
     image: reportportal/service-authorization:5.3.1
+    logging:
+      driver: "json-file"
+      options:
+        max-file: 5
+        max-size: 10m
     #ports:
     #  - "9999:9999"
     environment:
@@ -157,6 +187,11 @@ services:
 
   index:
     image: reportportal/service-index:5.0.10
+    logging:
+      driver: "json-file"
+      options:
+        max-file: 5
+        max-size: 10m
     depends_on:
       gateway:
         condition: service_started
@@ -173,6 +208,11 @@ services:
 
   api:
     image: reportportal/service-api:5.3.1
+    logging:
+      driver: "json-file"
+      options:
+        max-file: 10
+        max-size: 10m
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -207,6 +247,11 @@ services:
 
   ui:
     image: reportportal/service-ui:5.3.1
+    logging:
+      driver: "json-file"
+      options:
+        max-file: 5
+        max-size: 10m
     environment:
       - RP_SERVER_PORT=8080
     labels:
@@ -221,6 +266,11 @@ services:
 
   minio:
     image: minio/minio:RELEASE.2020-05-01T22-19-14Z
+    logging:
+      driver: "json-file"
+      options:
+        max-file: 5
+        max-size: 10m
     #ports:
     #  - '9000:9000'
     volumes:


### PR DESCRIPTION
Docker doesn’t limit the size of the files or how many log files there can be for a single container.