### PR TITLE
RP_ENVIRONMENT_VARIABLE_CLEAN_STORAGE_CHUNKSIZE ADD

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -259,6 +259,7 @@ services:
       RP_ENVIRONMENT_VARIABLE_CLEAN_LAUNCH_CRON: 0 0 */24 * * *
       RP_ENVIRONMENT_VARIABLE_CLEAN_STORAGE_CRON: 0 0 */24 * * *
       RP_ENVIRONMENT_VARIABLE_STORAGE_PROJECT_CRON: 0 */5 * * * *
+      RP_ENVIRONMENT_VARIABLE_CLEAN_STORAGE_CHUNKSIZE: 1000
     labels:
     - traefik.http.middlewares.jobs-strip-prefix.stripprefix.prefixes=/jobs
     - traefik.http.routers.jobs.middlewares=jobs-strip-prefix@docker


### PR DESCRIPTION
Hello guys, 

I think that the variable **"RP_ENVIRONMENT_VARIABLE_CANLE_STORAGE_CHUNKSIZE"** should be in this file for more transparency for users who use it. Since this variable in its default value can be a big problem for users with a large number of projects, logs and attachments.