### PR TITLE
release v23.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
 
   ## An analyzer instance for main functionality, don't forget to use the same storage settings (either MinIO, or filesystem) for analyzer_train
   analyzer: 
-    image: reportportal/service-auto-analyzer:5.7.4
+    image: reportportal/service-auto-analyzer:5.7.5
     environment:
       LOGGING_LEVEL: info
       AMQP_EXCHANGE_NAME: analyzer-default
@@ -75,7 +75,7 @@ services:
   
   ## An analyzer instance for training, don't forget to setup the same storage (either MinIO, or filesystem) as for main analyzer
   analyzer_train:
-    image: reportportal/service-auto-analyzer:5.7.4
+    image: reportportal/service-auto-analyzer:5.7.5
     environment:
       LOGGING_LEVEL: info
       AMQP_EXCHANGE_NAME: analyzer-default
@@ -96,7 +96,7 @@ services:
  
   ## Metrics service for analyzing how analyzer is working and manage retrained models
   metrics-gatherer: 
-    image: reportportal/service-metrics-gatherer:5.7.3
+    image: reportportal/service-metrics-gatherer:5.7.4
     environment:
       LOGGING_LEVEL: info
       ES_HOST: http://elasticsearch:9200
@@ -117,8 +117,8 @@ services:
     restart: always
 
   ## Initial reportportal db schema. Run once.
-  db-scripts:
-    image: reportportal/migrations:5.7.3
+  migrations:
+    image: reportportal/migrations:5.8.0
     depends_on:
       postgres:
         condition: service_healthy
@@ -172,7 +172,7 @@ services:
     restart: always
 
   rabbitmq:
-    image: rabbitmq:3.7.16-management
+    image: bitnami/rabbitmq:3.10.8-debian-11-r7
     # ports:
     #   - "5672:5672"
     #   - "15672:15672"
@@ -197,7 +197,16 @@ services:
       RP_BINARYSTORE_MINIO_ENDPOINT: http://minio:9000
       RP_BINARYSTORE_MINIO_ACCESSKEY: minio
       RP_BINARYSTORE_MINIO_SECRETKEY: minio123
-      RP_SESSION_LIVE: 86400 #in seconds
+      RP_SESSION_LIVE: 86400 # in seconds
+      RP_SAML_SESSION-LIVE: 4320
+      ## The initial password for superadmin user on FIRST launch. If the password was changed from the UI, this value can't change the password on redeployments.
+      RP_INITIAL_ADMIN_PASSWORD: "erebus"
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://0.0.0.0:9999/health || exit 1
+      interval: 60s
+      timeout: 30s
+      retries: 5
+      start_period: 60s
     labels:
       - "traefik.http.middlewares.uat-strip-prefix.stripprefix.prefixes=/uat"
       - "traefik.http.routers.uat.middlewares=uat-strip-prefix@docker"
@@ -212,7 +221,7 @@ services:
         condition: service_healthy
 
   index:
-    image: reportportal/service-index:5.7.3
+    image: reportportal/service-index:5.8.0
     depends_on:
       gateway:
         condition: service_started
@@ -228,7 +237,7 @@ services:
     restart: always
 
   api:
-    image: reportportal/service-api:5.7.4
+    image: reportportal/service-api:5.8.0
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -257,6 +266,12 @@ services:
       RP_REQUESTLOGGING: false
       MANAGEMENT_HEALTH_ELASTICSEARCH_ENABLED: false
       JAVA_OPTS: -Xmx1g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp  -Dcom.sun.management.jmxremote.rmi.port=12349 -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false  -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=0.0.0.0
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://0.0.0.0:8585/health || exit 1
+      interval: 60s
+      timeout: 30s
+      retries: 5
+      start_period: 60s
     labels:
       - "traefik.http.middlewares.api-strip-prefix.stripprefix.prefixes=/api"
       - "traefik.http.routers.api.middlewares=api-strip-prefix@docker"
@@ -268,7 +283,7 @@ services:
     restart: always
     
   jobs:
-    image: reportportal/service-jobs:5.7.4
+    image: reportportal/service-jobs:5.8.0
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -304,6 +319,12 @@ services:
       RP_PROCESSING_LOG_MAXBATCHSIZE: 2000
       RP_PROCESSING_LOG_MAXBATCHTIMEOUT: 6000
       RP_AMQP_MAXLOGCONSUMER: 1
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://0.0.0.0:8686/health || exit 1
+      interval: 60s
+      timeout: 30s
+      retries: 5
+      start_period: 60s
     labels:
     - traefik.http.middlewares.jobs-strip-prefix.stripprefix.prefixes=/jobs
     - traefik.http.routers.jobs.middlewares=jobs-strip-prefix@docker
@@ -315,7 +336,7 @@ services:
     restart: always
 
   ui:
-    image: reportportal/service-ui:5.7.4
+    image: reportportal/service-ui:5.8.0
     environment:
       - RP_SERVER_PORT=8080
     labels:


### PR DESCRIPTION
## Release v23.1 (5.8.0)

### Docker Compose changes:

#### UAT
1. New env `RP_SAML_SESSION-LIVE` 
2. New env `RP_INITIAL_ADMIN_PASSWORD`


#### JOBS
New env for Double Entry that processes logs by Jobs service (log per ms):
1. `RP_PROCESSING_LOG_MAXBATCHSIZE` 
2. `RP_PROCESSING_LOG_MAXBATCHTIMEOUT`


#### GENETAL
1. RabbitMQ updated to `bitnami/rabbitmq:3.10.8-debian-11-r7`
2. Added health checks to Java services


#### VERSIONS

1. reportportal/service-index:5.8.0
5. reportportal/service-authorization:5.8.0
6. reportportal/service-ui:5.8.0
7. reportportal/service-api:5.8.0
8. reportportal/service-jobs:5.8.0
9. reportportal/migrations:5.8.0
10. reportportal/service-auto-analyzer:5.7.5
11. reportportal/service-metrics-gatherer:5.7.4

❗️**All changes tested on QA and local env**