### PR TITLE
Update docker-compose.yml to explicitly set rabbitmq urls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,6 +260,7 @@ services:
       - reportportal
     restart: always
 
+
   uat:
     image: reportportal/service-authorization:5.8.2
     logging:
@@ -341,10 +342,6 @@ services:
       RP_DB_NAME: reportportal
       RP_AMQP_ADDRESSES: amqp://rabbitmq:rabbitmq@rabbitmq:5672
       RP_AMQP_API-ADDRESS: http://rabbitmq:rabbitmq@rabbitmq:15672/api
-      RP_AMQP_USER: rabbitmq
-      RP_AMQP_PASS: rabbitmq
-      RP_AMQP_APIUSER: rabbitmq
-      RP_AMQP_APIPASS: rabbitmq
       RP_AMQP_ANALYZER-VHOST: analyzer
       RP_BINARYSTORE_TYPE: minio
       DATASTORE_ENDPOINT: http://minio:9000
@@ -396,10 +393,6 @@ services:
       RP_DB_NAME: reportportal
       RP_AMQP_ADDRESSES: amqp://rabbitmq:rabbitmq@rabbitmq:5672
       RP_AMQP_API-ADDRESS: http://rabbitmq:rabbitmq@rabbitmq:15672/api
-      RP_AMQP_USER: rabbitmq
-      RP_AMQP_PASS: rabbitmq
-      RP_AMQP_APIUSER: rabbitmq
-      RP_AMQP_APIPASS: rabbitmq
       RP_AMQP_ANALYZER-VHOST: analyzer
       DATASTORE_TYPE: minio
       DATASTORE_ENDPOINT: http://minio:9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -339,6 +339,8 @@ services:
       RP_DB_USER: rpuser
       RP_DB_PASS: rppass
       RP_DB_NAME: reportportal
+      RP_AMQP_ADDRESSES: amqp://rabbitmq:rabbitmq@rabbitmq:5672
+      RP_AMQP_API-ADDRESS: http://rabbitmq:rabbitmq@rabbitmq:15672/api
       RP_AMQP_USER: rabbitmq
       RP_AMQP_PASS: rabbitmq
       RP_AMQP_APIUSER: rabbitmq
@@ -392,6 +394,8 @@ services:
       RP_DB_USER: rpuser
       RP_DB_PASS: rppass
       RP_DB_NAME: reportportal
+      RP_AMQP_ADDRESSES: amqp://rabbitmq:rabbitmq@rabbitmq:5672
+      RP_AMQP_API-ADDRESS: http://rabbitmq:rabbitmq@rabbitmq:15672/api
       RP_AMQP_USER: rabbitmq
       RP_AMQP_PASS: rabbitmq
       RP_AMQP_APIUSER: rabbitmq


### PR DESCRIPTION
Please add:

 - [ ] A reference to a related issue, via `#`
 - [ ] `@mentions` of the person or team responsible for reviewing proposed changes.
 - [ ] Start message with corresponding icon:
 -  🐛 fixing a bug
 - 📝 updating documentation

 The rabbit configuration is partly set and partly derived from internal app code. I updated the docker-compose to explicitly set the rabbitmq URLs so it is easy to see how they come into the application and change them. 
