### PR TITLE
fix: RabbitMQ - adding env for disk free limit default to 50MB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,6 +140,7 @@ services:
       RABBITMQ_DEFAULT_USER: *rabbitmq_user
       RABBITMQ_DEFAULT_PASS: *rabbitmq_password
       RABBITMQ_MANAGEMENT_ALLOW_WEB_ACCESS: "true"
+      RABBITMQ_DISK_FREE_ABSOLUTE_LIMIT: 50MB
       RABBITMQ_PLUGINS: >
         rabbitmq_consistent_hash_exchange
         rabbitmq_management


### PR DESCRIPTION
@irynakozak2 @raikbitters please, review :)

 -  🐛 fixing a bug with rabbitMq image env variable

More info: 
https://stackoverflow.com/questions/70742426/rabbitmq-free-disk-space-is-insufficient
https://www.rabbitmq.com/docs/disk-alarms




 
