### PR TITLE
Update uat version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -401,7 +401,7 @@ services:
   ## - Routed via Traefik under path `/uat`
   ##
   uat:
-    image: ${UAT_IMAGE-reportportal/service-authorization:5.14.0}
+    image: ${UAT_IMAGE-reportportal/service-authorization:5.14.1}
     build: ./service-authorization
     logging:
       <<: *logging


### PR DESCRIPTION
This pull request includes a minor version update for the `uat` service in the `docker-compose.yml` file.

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L404-R404): Updated the `uat` service image from `5.14.0` to `5.14.1` to include the latest changes or fixes in the `service-authorization` component.
 
