### PR TITLE
Bitnamilegacy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,7 +167,7 @@ services:
   ## - Includes optional plugins for dashboard, LDAP, shovel, etc.
   ##
   rabbitmq:
-    image: bitnamilegacy.rabbitmq:4.1.2-debian-12-r1
+    image: bitnamilegacy/rabbitmq:4.1.2-debian-12-r1
     logging:
       <<: *logging
     # ports:


### PR DESCRIPTION
Changed `docker.io/bitnami` to `docker.io/bitnamilegacy` repository due to Bitnami policy changes https://github.com/bitnami/containers/issues/83267