### PR TITLE
📝 updating documentation: Change docker compose commands for ReportPortal

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ It's the best way for demo purposes and small teams. The database is already in 
 3. Deploy ReportPortal using `docker compose plugin` within the same folder
 
 ```bash
-docker compose --profile "*" up
+docker compose --profile "*" -p reportportal up
 ```
 
 To start ReportPortal in daemon mode, add '-d' argument:
 
 ```bash
-docker compose --profile "*" up -d
+docker compose --profile "*" -p reportportal up -d
 ```
 
 4. Open in your browser IP address of deployed environment at port `8080`


### PR DESCRIPTION
Small fix on the Readme, as I was not able to run it as in the example.
I had the error "no service selected"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to use docker compose --profile "*" -p reportportal up (and ... up -d) instead of the previous project-name flag. Clarifies profile-based service selection for starting all defined services and improves consistency/readability for local deployments. No application code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->