### PR TITLE
EPMRPP-118487 | Fix analyzer PermissionError on train_models by chowning storage volume for DHI non-root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   - [Installation steps](#installation-steps)
     - [Simple setup with Docker](#simple-setup-with-docker)
     - [Production-ready set and Custom deployment with Docker](#production-ready-set-and-custom-deployment-with-docker)
+  - [Troubleshooting](#troubleshooting)
   - [Integration. How to get log data in](#integration-how-to-get-log-data-in)
   - [Contribution](#contribution)
   - [Documentation](#documentation)
@@ -103,6 +104,16 @@ For production usage, we recommend:
 - choose only required Bug Tracking System integration service. Exclude the rest
 
 To customize deployment and make it production-ready please follow [customization steps and details](https://github.com/reportportal/reportportal/wiki/Production-Ready-set-and-Deployment-Customization)
+
+## Troubleshooting
+
+If the `analyzer` service fails on the `train_models` task with
+`PermissionError: [Errno 13] Permission denied: '/data/storage/analyzer'`,
+it's because the analyzer image (DHI-based since 5.15.5) runs as a non-root
+user while Docker creates the `analyzer-storage` volume root-owned. This is
+handled automatically by the `analyzer-storage-init` job in
+`docker-compose.yml`, which chowns the volume to the analyzer's runtime
+UID/GID before `analyzer` starts.
 
 ## Integration. How to get log data in
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -602,6 +602,40 @@ services:
   ## Analyzer services (optional): auto-analysis and ML training
   ##
 
+  ## @param analyzer-storage-init One-off job that fixes ownership of the analyzer storage volume
+  ## - Since 5.15.5 the analyzer image is built from a Docker Hardened Image
+  ##   (DHI) base and runs as non-root UID/GID 65532 by default
+  ## - Docker Compose creates a brand-new named volume owned by root, so the
+  ##   analyzer process cannot create FILESYSTEM_DEFAULT_PATH
+  ##   (/data/storage/analyzer) on it without this fix, and fails with
+  ##   `PermissionError: [Errno 13] Permission denied: '/data/storage/analyzer'`
+  ##   while processing the `train_models` task
+  ## - Runs as root once, pre-creates the analyzer subfolder and re-chowns the
+  ##   whole volume to the analyzer's runtime UID/GID, then exits
+  ##
+  analyzer-storage-init:
+    image: ${ANALYZER_IMAGE-reportportal/service-auto-analyzer:5.15.5}
+    build: ./service-auto-analyzer
+    user: "0:0"
+    entrypoint:
+      - python
+      - -c
+      - |
+        import os
+        UID = GID = 65532  # DHI python image default non-root user
+        os.makedirs("/data/storage/analyzer", exist_ok=True)
+        for root, dirs, files in os.walk("/data/storage"):
+            for name in dirs + files:
+                os.chown(os.path.join(root, name), UID, GID)
+        os.chown("/data/storage", UID, GID)
+    volumes:
+      - analyzer-storage:/data/storage
+    networks:
+      - reportportal
+    restart: "no"
+    profiles:
+      - ''
+
   ## @param analyzer Automatic test result analyzer
   ## - Performs log analysis and pattern detection
   ## - Relies on OpenSearch and RabbitMQ
@@ -628,6 +662,8 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
+      analyzer-storage-init:
+        condition: service_completed_successfully
     networks:
       - reportportal
     restart: always


### PR DESCRIPTION
## Summary

Analyzer's `train_models` AMQP task fails with `PermissionError: [Errno 13] Permission denied: '/data/storage/analyzer'` on a fresh Docker Compose deployment. Root cause: the DHI (Docker Hardened Image) base image switch in `5.15.5` left the final container stage running as non-root (UID/GID `65532`) with no `USER root` override, while Docker creates new named volumes as `root:root`. This PR adds a one-off init job that provisions and chowns the storage volume before the analyzer starts.

## Root cause

- `service-auto-analyzer` switched its Dockerfile to a DHI Python 3.12 base in [`057256b6`](https://github.com/reportportal/service-auto-analyzer/commit/057256b6b782c5d82149ef161cb7dd742f89ab9e) ("Switch on DHI"), shipped in `5.15.5`.
- The following commit, [`e6bdd349`](https://github.com/reportportal/service-auto-analyzer/commit/e6bdd3494b7af5cdd388a89fc13d3505b0bfb890), removed `USER root` from the **final** stage only (kept in `test`/`builder` for `apt-get`). With no override, the final image inherits the DHI base's default user.
- Confirmed on the published image:
  ```
  $ docker inspect reportportal/service-auto-analyzer:5.15.5 --format '{{.Config.User}}'
  65532
  ```
- `docker-compose.yml` mounts a **named volume** (`analyzer-storage`) at `/data/storage`. Docker creates new named volumes as `root:root`, `0755` — nothing in the image bakes in a pre-existing `/data/storage` for Docker to inherit ownership from.
- UID `65532` has no write access to the root-owned mount, so `os.makedirs('/data/storage/analyzer', exist_ok=True)` fails. Reproducible for any write to that path, not just `train_models`.

## Fix

Adds an `analyzer-storage-init` one-off service to `docker-compose.yml`:

- Runs the same `analyzer` image as root (`user: "0:0"`)
- Mounts the shared `analyzer-storage` volume
- Creates `/data/storage/analyzer` and `chown`s the volume to `65532:65532`, then exits

`analyzer` now depends on `analyzer-storage-init` with `condition: service_completed_successfully`, so the fix runs ahead of the analyzer on every `docker compose up`. Idempotent — safe against an already-fixed volume, and doesn't touch other volumes.

**Why not a Dockerfile fix:** the final image stage has no shell (`sh`/`id` are not present) to run `chown` in, so a build-time fix isn't viable without reintroducing a root/shell stage. This approach works against the already-published `5.15.5` tag today, no rebuild required.

## Testing

**Isolated volume test** (no stack required):
```bash
docker volume create repro-analyzer-storage

# confirm fresh volume is root-owned
docker run --rm --user 0 -v repro-analyzer-storage:/data/storage \
  --entrypoint python reportportal/service-auto-analyzer:5.15.5 -c \
  "import os; st = os.stat('/data/storage'); print(oct(st.st_mode), st.st_uid, st.st_gid)"
# -> 0o40755 0 0

# reproduce the exact error as the container's default user
docker run --rm -v repro-analyzer-storage:/data/storage \
  --entrypoint python reportportal/service-auto-analyzer:5.15.5 -c \
  "import os; os.makedirs('/data/storage/analyzer', exist_ok=True)"
# -> PermissionError: [Errno 13] Permission denied: '/data/storage/analyzer'
```

**Init job verification:**
```bash
docker compose run --rm --no-deps analyzer-storage-init   # exit code 0

docker run --rm -v reportportal_analyzer-storage:/data/storage \
  --entrypoint python reportportal/service-auto-analyzer:5.15.5 -c \
  "import os
os.makedirs('/data/storage/analyzer', exist_ok=True)
open('/data/storage/analyzer/testfile.bin', 'wb').write(b'ok')
print('SUCCESS')"
# -> SUCCESS
```

**End-to-end verification** against the full stack (`docker compose up -d`), publishing the real `train_models` task to RabbitMQ (`analyzer-default` exchange, `analyzer` vhost):
```python
import pika, json
conn = pika.BlockingConnection(pika.URLParameters('amqp://rabbitmq:rabbitmq@rabbitmq:5672/analyzer'))
ch = conn.channel()
body = json.dumps({'model_type': 2, 'project': 1, 'additional_projects': None, 'gathered_metric_total': 0})
ch.basic_publish(exchange='analyzer-default', routing_key='train_models', body=body.encode('utf-8'))
```

Analyzer log — task completed with no `PermissionError`:
```
INFO - analyzerApp.retrainingService - Started training model for ModelType.suggestion in project 1
INFO - analyzerApp.retrainingService - Finished training 0.02 s
```

Artifact persisted, owned by the analyzer's runtime user:
```
/data/storage/analyzer/prj-1/suggestion_trigger_info  uid 65532  gid 65532  size 65
```

## Acceptance criteria

- [x] Analyzer can create `/data/storage/analyzer` and save triggering/training artifacts without `PermissionError`
- [x] `train_models` AMQP task completes successfully on local `develop` compose
- [x] Root cause documented (DHI base image dropping to non-root UID `65532` + root-owned named volume) and fix applied (`analyzer-storage-init` job)
